### PR TITLE
Simplify translation of terms

### DIFF
--- a/ai.finto.fi/static/js/annif.js
+++ b/ai.finto.fi/static/js/annif.js
@@ -38,13 +38,6 @@ function makeLabelLanguageOptions() {
     );
 }
 
-function getLabelPromise(uri, lang) {
-    return $.ajax({
-        url: "https://api.finto.fi/rest/v1/label?uri=" + uri + "&lang=" + lang,
-        method: 'GET'
-    });
-}
-
 function showResults(data) {
     $.each(data.results, function(idx, value) {
         $('#no-results').hide();
@@ -103,6 +96,7 @@ function getSuggestions() {
         method: 'POST',
         data: {
           text: $('#text').val(),
+          language: $('#label-language').val() == 'project-language' ? '' : $('#label-language').val(),
           limit: $('input[name="limit"]:checked').val(),
           threshold: 0.01
         },
@@ -114,34 +108,7 @@ function getSuggestions() {
                 $('#no-results').show();
             }
 
-            if ($('#label-language').val() == 'project-language') {
-                showResults(data);
-            }
-            else {
-                var promises = []
-                $.each(data.results, function(idx, value) {
-                    promises.push(
-                        getLabelPromise(value.uri, $('#label-language').val())
-                    );
-                });
-
-                $.when.apply($, promises).done(function(result) {
-                    $.each(promises, function(idx, promise) {
-                        var newLabel = promise.responseJSON.prefLabel;
-                        if (newLabel === undefined) {
-                            var projectLanguage = projects[$('#project').val()].language;
-                            newLabel = data.results[idx].label + ' (' + projectLanguage + ')';
-                        }
-                        data.results[idx].label = newLabel;
-                    });
-                    showResults(data);
-                }).fail(function (jqXHR) {
-                    alert('URI query on api.finto.fi failed:\n' + jqXHR.responseText);
-                    $('#results').hide();
-                    $('#no-results').show();
-                }
-                );
-            }
+            showResults(data);
         }
     });
 }


### PR DESCRIPTION
This PR simplifies translation of suggested terms by using the `language` parameter of Annif API's `suggest` method. Calls to Finto API are removed.

Implements #10